### PR TITLE
Allow filter on entire document if no selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,16 @@
   ],
   "main": "./out/src/extension",
   "contributes": {
+    "configuration": {
+      "title": "Filter Text configuration",
+      "properties": {
+        "filterText.useDocumentIfEmptySelection": {
+          "type": "boolean",
+          "default": true,
+          "description": "If no text is selected, filter the entire document."
+        }
+      }
+    },
     "commands": [
       {
         "command": "extension.filterTextInplace",


### PR DESCRIPTION
- Optionally apply entire document to filter command if there is no current selection.
- filterText.useDocumentIfEmptySelection configuration option added with default of true.
- Also remembers previously entered command
- Also scrolls new text into visible range
- If output filtered to new temp editor don't auto select all of it.