### PR TITLE
Added support and settings for using bash's commands or scripts (conv…

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,16 @@
           "type": "boolean",
           "default": true,
           "description": "If no text is selected, filter the entire document."
+        },
+        "filterText.invokeViaBash.windows": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether to invoke filter command via bash on windows."
+        },
+        "filterText.bashPath.windows": {
+          "type": "string",
+          "default": "C:/cygwin/bin/bash.exe",
+          "description": "Path of the bash to use.  Default to Cygwin's path."
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -139,7 +139,13 @@ function executeCommand(name: string, args: string[], inputText: string, options
                 run(path, args, resolve);
             });
         } else {
-            let prependArgs = ['-lc', '"$@"', '[bash]', name];
+            let prependArgs;
+            let cwd = options['cwd'];
+            // invoke bash with "-l" (--login) option.  This is needed for Cygwin where the Cygwin's C:/cygwin/bin path may exist in PATH only after --login.
+            if (cwd != null)
+                prependArgs = ['-lc', 'cd "$0"; "$@"', cwd, name]; // set current working directory after bash's --login (-l)
+            else
+                prependArgs = ['-lc', '"$@"', '[bash]', name];
             run(bashPath, prependArgs.concat(args), resolve);
         }
     });


### PR DESCRIPTION
…eniently) on Windows.

Extended support to leverage the power of bash on Windows for this great plugin.  Otherwise, it is not powerful on Windows.  (default to Cygwin's bash path when user turn on the `"filterText.invokeViaBash.windows": true` setting)