### PR TITLE
A bug fix and better error reporting

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -118,8 +118,8 @@ function executeCommand(name: string, args: string[], inputText: string, options
 
             if (inputText.length > 0) {
                 filter.stdin.write(inputText);
-                filter.stdin.end();
             }
+            filter.stdin.end();
 
             let filteredText = '';
             filter.stdout.on('data', function (data) {


### PR DESCRIPTION
1. A bug fix: when filter on empty document -> child process never ends.
2. Better error reporting: In case command have explicit error messages (on stderr) and exited with failure status, and nothing output in stdout --> don't change text selection but pop an error message instead.  (grep command with no match will still be treated as success, although it return a failure status)

The second change can help to know why a command fail.

I think these changes improve the plugin.  Thanks.