### PR TITLE
Fix #9, for new file (e.g. untitled), the current directory should st…

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import * as os from 'os';
 import * as glob from 'glob';
 import * as which from 'which';
 import * as shell_quote from 'shell-quote';
+import { dirname } from 'path';
 
 let lastEntry: string = '';
 
@@ -180,12 +181,13 @@ function getCurrentWorkingDirectory(): string {
             return folder.uri.fsPath;
         }
 
-        try {
-          const folders = vscode.workspace.workspaceFolders;
-          if (folders.length > 0) {
-              return folders[0].uri.fsPath;
-          }
-        } catch(err) {
+        const folders = vscode.workspace.workspaceFolders;
+        if (folders != undefined && folders.length > 0) {
+            return folders[0].uri.fsPath;
+        }
+        // Github #9: if no workspace folders, and uri.scheme !== 'untitled' (i.e. existing file), use folder of that file. Otherwise, use user home directory.
+        if (uri.scheme !== 'untitled') {
+            return dirname(uri.fsPath);
         }
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -173,7 +173,8 @@ function getTempEditor(content: string): PromiseLike<vscode.TextEditor> {
 function getCurrentWorkingDirectory(): string {
     const uri = vscode.window.activeTextEditor.document.uri;
 
-    if (uri && uri.scheme === 'file') {
+    const isFileOrUntitledDocument = uri && (uri.scheme === 'file' || uri.scheme === 'untitled');
+    if (isFileOrUntitledDocument) {
         const folder = vscode.workspace.getWorkspaceFolder(uri);
         if (folder) {
             return folder.uri.fsPath;


### PR DESCRIPTION
…ill be a first workspace folder, if any workspace folder is opened.  Otherwise, default to user's home directory.

To reproduce, type Cmd-N or Ctrl-N to create a new file.  Invoke Filter Text and type `pwd` and enter.