### PR TITLE
Improvement: Add option to always use a file's dir as current working…

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,11 @@
           "type": "string",
           "default": "C:/cygwin/bin/bash.exe",
           "description": "Path of the bash to use.  Default to Cygwin's path."
+        },
+        "filterText.useDocumentDirAsWorkDir": {
+          "type": "boolean",
+          "default": false,
+          "description": "Always use the path of the current file as the current working dir instead of the heuristic."
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -176,6 +176,13 @@ function getCurrentWorkingDirectory(): string {
 
     const isFileOrUntitledDocument = uri && (uri.scheme === 'file' || uri.scheme === 'untitled');
     if (isFileOrUntitledDocument) {
+        const useDocumentDirAsWorkDir = vscode.workspace.getConfiguration('filterText').useDocumentDirAsCwd;
+
+        if (useDocumentDirAsWorkDir && uri.scheme === 'file') {
+            vscode.window.showInformationMessage('Using doc dir as cwd; dirname: ' + dirname(uri.fsPath));
+            return dirname(uri.fsPath);
+        }
+
         const folder = vscode.workspace.getWorkspaceFolder(uri);
         if (folder) {
             return folder.uri.fsPath;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -176,7 +176,7 @@ function getCurrentWorkingDirectory(): string {
 
     const isFileOrUntitledDocument = uri && (uri.scheme === 'file' || uri.scheme === 'untitled');
     if (isFileOrUntitledDocument) {
-        const useDocumentDirAsWorkDir = vscode.workspace.getConfiguration('filterText').useDocumentDirAsCwd;
+        const useDocumentDirAsWorkDir = vscode.workspace.getConfiguration('filterText').useDocumentDirAsWorkDir;
 
         if (useDocumentDirAsWorkDir && uri.scheme === 'file') {
             vscode.window.showInformationMessage('Using doc dir as cwd; dirname: ' + dirname(uri.fsPath));


### PR DESCRIPTION
… dir

The added option lets the user configure to always use a file's
directory as the current working directory - instead of the internal
heuristic. This will only be done if explicitly configured and the
uri.scheme is 'file'.