### PR TITLE
Implemented passing in the command as an argument. Implements Github #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ It brings the power of Unix commands such as `sort` and `uniq` into your VS Code
 
 ![Filter selected text](images/filtertext.gif)
 
+### Keybindings
+
+It is possible to map specific commands to key bindings. Example usage in `keybindings.json`:
+
+```
+{
+    "key": "shift+alt+l",
+    "command": "extension.filterTextInplace",
+    "args": { "cmd": "sort" }
+}
+```
+
 ## Changes
 
 * 03/14/2019: v0.0.12 - Improvement: Add option to always use a file's dir as current working


### PR DESCRIPTION
The command can optionally be passed in as a hash map with a key "cmd"
of type string. This can be used in keybindings.json. The hash map is
used to possibly add more options being passed in the future.