### PR TITLE
Predefined commands via settings.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 out
 node_modules
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It brings the power of Unix commands such as `sort` and `uniq` into your VS Code
 ### NOTE
 
 * If you didn't select anything, it simply inserts the result text at the current cursor position.
-* If you selected `Filter Text` command it opens temp editor with the result
+* If you selected `Filter Text` command it opens temp editor with the result.
 
 
 ![Filter selected text](images/filtertext.gif)
@@ -22,7 +22,7 @@ It brings the power of Unix commands such as `sort` and `uniq` into your VS Code
 
 It is possible to map specific commands to key bindings. Example usage in `keybindings.json`:
 
-```
+```json
 {
     "key": "shift+alt+l",
     "command": "extension.filterTextInplace",
@@ -30,6 +30,30 @@ It is possible to map specific commands to key bindings. Example usage in `keybi
 }
 ```
 
+### Configuration
+
+Commands can be predefined in the `settings.json` as follows:
+
+```json
+"filterText.commandList": [
+    {
+        "name": "Sort unique",
+        "description": "Sorts and find the unique entries",
+        "command": "sort | uniq"
+    },
+    {
+        "name": "Columnize CSV",
+        "description": "Columnize comma separated values",
+        "command": "column -s \",\" -t"
+    },
+    {
+        "name": "XML lint",
+        "description": "Run the command through xmllint",
+        "command": "xmllint --format -"
+    }
+]
+
+```
 ## Changes
 
 * 03/31/2019: v0.0.14 - Fix used document filter flag when false

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   },
   "activationEvents": [
     "onCommand:extension.filterTextInplace",
-    "onCommand:extension.filterText"
+    "onCommand:extension.filterText",
+    "onCommand:extension.filterPredefined"
   ],
   "main": "./out/src/extension",
   "contributes": {
@@ -46,17 +47,46 @@
           "type": "boolean",
           "default": false,
           "description": "Always use the path of the current file as the current working dir instead of the heuristic."
+        },
+        "filterText.commandList": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "title": "inner objects",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The name of the command entry."
+              },
+              "description": {
+                "type": "string",
+                "description": "Description of the command."
+              },
+              "command": {
+                "type": "string",
+                "description": "The actual command to invoke, e.g. sort | uniq."
+              }
+            }
+          },
+          "description": "List of predefined commands"
         }
       }
     },
     "commands": [
       {
         "command": "extension.filterTextInplace",
-        "title": "Filter Text Inplace"
+        "title": "Filter text in-place",
+        "category": "FilterText"
+      },
+      {
+        "command": "extension.filterPredefined",
+        "title": "Run predefined filter",
+        "category": "FilterText"
       },
       {
         "command": "extension.filterText",
-        "title": "Filter Text"
+        "title": "Run filter through selected text",
+        "category": "FilterText"
       }
     ],
     "keybindings": [


### PR DESCRIPTION
This pull request contains an addition to your extension. Via the `settings.json` you are now able to predefine commands. The commands are displayed via a QuickPick menu.

Before doing any more work (this is my first Typescript experience..) and risking doing too much work which you are not willing to merge :), is this something which can be helpful to the extension? 

Please check out the code. Any criticism is welcome!