### PR TITLE
Add macOS keybinding to fix Delete All Right

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ It brings the power of Unix commands such as `sort` and `uniq` into your VS Code
 ## Usage
 
 * Select text that you want to filter.
-* Press `Ctrl+K Ctrl+F` (or press `F1` and run the command named `Filter Text Inplace`).
+* Press `Ctrl+K Ctrl+F` (`⌘K ⌘F` on macOS).
+    * Alternatively, press `F1` and run the command named `Filter Text Inplace`.
 * Type shell command like `sort -r` and press enter.
 * It replaces the selected text with the text from stdout of the command.
 

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "keybindings": [
       {
         "key": "ctrl+k ctrl+f",
+        "mac": "cmd+k cmd+f",
         "command": "extension.filterTextInplace",
         "when": "editorTextFocus"
       }


### PR DESCRIPTION
This sets a mac-specific keybinding of `⌘K ⌘F` to trigger Filter Text.

Context:

Without a macOS-specific keybinding, Filter Text overrides the default behavior of `ctrl+k`, which is to delete all text to the right of the cursor (Delete All Right).  This "kill-line" behavior is also the behavior of `ctrl+k` in most other macOS applications.

On macOS, VS Code uses `cmd+k` where it uses `ctrl+k` in other systems. In adding the mac keybinding, Filter Text no longer clobber the system-wide default.

It also fixes how Filter Text is displayed in Keyboard Shortcuts.  Previously, searching for `ctrl+k` on a Mac would show Delete All Right still mapped to it even though Filter Text was actually responding. (That made figuring out why `ctrl+k` no longer worked especially difficult.)